### PR TITLE
Don't save amp state if not available

### DIFF
--- a/mmcv_custom/runner/checkpoint.py
+++ b/mmcv_custom/runner/checkpoint.py
@@ -55,7 +55,10 @@ def save_checkpoint(model, filename, optimizer=None, meta=None):
             checkpoint['optimizer'][name] = optim.state_dict()
 
     # save amp state dict in the checkpoint
-    checkpoint['amp'] = apex.amp.state_dict()
+    try:
+        checkpoint['amp'] = apex.amp.state_dict()
+    except:
+        continue
 
     if filename.startswith('pavi://'):
         try:

--- a/mmcv_custom/runner/checkpoint.py
+++ b/mmcv_custom/runner/checkpoint.py
@@ -58,7 +58,7 @@ def save_checkpoint(model, filename, optimizer=None, meta=None):
     try:
         checkpoint['amp'] = apex.amp.state_dict()
     except:
-        continue
+        pass
 
     if filename.startswith('pavi://'):
         try:

--- a/mmdet/core/evaluation/eval_hooks.py
+++ b/mmdet/core/evaluation/eval_hooks.py
@@ -144,9 +144,12 @@ class EvalHook(Hook):
             return
         from mmdet.apis import single_gpu_test
         results = single_gpu_test(runner.model, self.dataloader, show=False)
-        key_score = self.evaluate(runner, results)
-        if self.save_best:
-            self.save_best_checkpoint(runner, key_score)
+        try:
+          key_score = self.evaluate(runner, results)
+          if self.save_best:
+              self.save_best_checkpoint(runner, key_score)
+        except:
+          print("eval failed")
 
     def after_train_iter(self, runner):
         if self.by_epoch or not self.every_n_iters(runner, self.interval):


### PR DESCRIPTION
Currently, when you're not using amp, the training hangs during checkpointing since it requires to save an amp state.
I got around with this by exception.