### PR TITLE
Rename 'sklearn' to 'scikit-learn' in optional.txt

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -3,4 +3,4 @@ cityscapesscripts
 imagecorruptions
 mmlvis
 scipy
-sklearn
+scikit-learn


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands.